### PR TITLE
Update the version of `miow`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/davidhewitt/mio-anonymous-pipes"
 
 [dependencies]
 mio = "0.6"
-miow = "0.3"
+miow = "0.6"
 winapi = { version = "0.3.5", features = ["ioapiset"] }
 spsc-buffer = "0.1"
 parking_lot = "0.11.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,8 +198,9 @@ impl Drop for EventedAnonRead {
         let thread = self.thread.take().unwrap();
 
         // Stop reader thread waiting for pipe contents
+
         unsafe {
-            CancelSynchronousIo(thread.as_raw_handle());
+            CancelSynchronousIo(std::mem::transmute(thread.as_raw_handle()));
         }
 
         thread


### PR DESCRIPTION
Updates the version of `miow` that this crate uses to get it to work with Warp on Windows. Without this there are duplicate types from different versions of the same crate being pulled in.