### PR TITLE
Bump parking lot version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ mio = "0.6"
 miow = "0.6"
 winapi = { version = "0.3.5", features = ["ioapiset"] }
 spsc-buffer = "0.1"
-parking_lot = "0.11.1"
+parking_lot = "0.12"


### PR DESCRIPTION
Here, we bump the parking lot version to avoid downgrading the version used by `warp-internal` when adding this crate as a dependency.

I had `warp-internal` point to this locally and it fixes all `Cargo.lock` changes involving `parking-lot`.